### PR TITLE
Add CSS over JS guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Interfaces succeed because of hundreds of choices. This is a living, non-exhaust
 - **Preload fonts.** For critical text to avoid flash & layout shift.
 - **Subset fonts.** Ship only the code points/scripts you use via unicode-range (limit variable axes to what you need) to shrink size.
 - **Don’t use the main thread for expensive work.** Move especially long tasks to [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) to avoid blocking interaction with the page.
+- **CSS over JS.** Use CSS for conditional styles instead of JavaScript (eg: React props) where possible, using features such as [:has()](https://developer.mozilla.org/en-US/docs/Web/CSS/:has), [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors), & other [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).
 
 ## Design
 


### PR DESCRIPTION
This adds a new guideline to the Performance section that recommends the use of CSS features for conditionally applying styles instead of relying on JavaScript.

The idea behind this guideline is that where possible, developers should be writing only as much JavaScript as necessary.

Modern CSS features such as `:has()` are extremely powerful and can be leveraged to greatly reduce overall code needed. By leveraging these features for state-dependent styles, those styles can be statically defined and thus reduce unnecessary re-renders. Often times in cases such as form elements, state can be derived from HTML attributes, negating the need for additional conditionally applied classes in JS. In rare cases where a value must come from JS (such as a mouse cursor position), that value can be passed using an inline `style` attribute and a CSS custom property (eg: `--mouse-x`).

Good examples can be found in [this article on replacing React code with CSS](https://www.developerway.com/posts/replacing-react-with-css) and [this interactive guide to :has()](https://ishadeed.com/article/css-has-guide/).

Please feel free to adjust the wording of this new guideline. I attempted to be concise, but it may be too vague.