### PR TITLE
Fix curly quote guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Concise rules for building accessible, fast, delightful UIs. Use MUST/SHOULD/NEV
 - MUST: `<title>` matches current context
 - MUST: No dead ends; always offer next step/recovery
 - MUST: Design empty/sparse/dense/error states
-- SHOULD: Curly quotes (" "); avoid widows/orphans (`text-wrap: balance`)
+- SHOULD: Curly quotes (“ ”); avoid widows/orphans (`text-wrap: balance`)
 - MUST: `font-variant-numeric: tabular-nums` for number comparisons
 - MUST: Redundant status cues (not color-only); icons have text labels
 - MUST: Accessible names exist even when visuals omit labels

--- a/command.md
+++ b/command.md
@@ -57,7 +57,7 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 ### Typography
 
 - `…` not `...`
-- Curly quotes `"` `"` not straight `"`
+- Curly quotes `“` `”` not straight `"`
 - Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
 - Loading states end with `…`: `"Loading…"`, `"Saving…"`
 - `font-variant-numeric: tabular-nums` for number columns/comparisons


### PR DESCRIPTION
- Use actual U+201C and U+201D characters in the agent-facing guidelines.
- Fixes #26